### PR TITLE
Improve issue metadata unpacking

### DIFF
--- a/sentry2csv/sentry2csv.py
+++ b/sentry2csv/sentry2csv.py
@@ -94,10 +94,26 @@ def write_csv(filename: str, issues: List[Dict[str, Any]]):
         writer.writeheader()
         for issue in issues:
             try:
+                # mapping from
+                #  https://github.com/getsentry/sentry/blob/9910cc917d2def63b110e75d4d17dedf7f415f58/src/sentry/static/sentry/app/utils/events.tsx#L7  # pylint: disable=line-too-long
+                issue_type = issue["type"]
+                if issue_type == "error":
+                    error = issue["metadata"]["type"]
+                    details = issue["metadata"]["value"]
+                elif issue_type == "csp":
+                    error = "csp"
+                    details = issue["metadata"]["message"]
+                elif issue_type == "default":
+                    error = "default"
+                    details = issue["metadata"].get("title", "")
+                else:
+                    logger.debug("Unknown issue type: %s\n%s", issue_type, issue)
+                    error = issue_type
+                    details = ""
                 row = {
-                    "Error": issue["metadata"]["type"],
+                    "Error": error,
                     "Location": issue["culprit"],
-                    "Details": issue["metadata"]["value"],
+                    "Details": details,
                     "Events": issue["count"],
                     "Users": issue["userCount"],
                     "Notes": "",

--- a/tests/test_sentry2csv.py
+++ b/tests/test_sentry2csv.py
@@ -1,4 +1,5 @@
 """Test te Sentry project."""
+# pylint: disable=line-too-long
 
 from io import StringIO
 from unittest.mock import call, mock_open
@@ -167,6 +168,7 @@ def test_write_csv(mocker):
                 "count": 123,
                 "userCount": 3,
                 "permalink": "https://sentry.io/warning/warning_details",
+                "type": "error",
             },
             {
                 "metadata": {"type": "error", "value": "explanation of error"},
@@ -174,6 +176,32 @@ def test_write_csv(mocker):
                 "count": 12,
                 "userCount": 10,
                 "permalink": "https://sentry.io/error/error_details",
+                "type": "error",
+            },
+            {
+                "metadata": {"message": "a CSP error"},
+                "culprit": "culprit body",
+                "count": 12,
+                "userCount": 10,
+                "permalink": "https://sentry.io/error/error_details",
+                "type": "csp",
+            },
+            {
+                "metadata": {},
+                "culprit": "culprit body",
+                "count": 12,
+                "userCount": 10,
+                "permalink": "https://sentry.io/error/error_details",
+                "type": "hpkp",
+            },
+            {
+                "metadata": {"title": "successful JS title"},
+                "culprit": "https://www.example.com/culprit/path",
+                "count": 12,
+                "userCount": 10,
+                "permalink": "https://sentry.io/error/error_details",
+                "type": "default",
+                "platform": "javascript",
             },
         ],
     )
@@ -182,6 +210,9 @@ def test_write_csv(mocker):
         "Error,Location,Details,Events,Users,Notes,Link\r",
         "warning,culprit body,explanation of warning,123,3,,https://sentry.io/warning/warning_details\r",
         "error,culprit body,explanation of error,12,10,,https://sentry.io/error/error_details\r",
+        "csp,culprit body,a CSP error,12,10,,https://sentry.io/error/error_details\r",
+        "hpkp,culprit body,,12,10,,https://sentry.io/error/error_details\r",
+        "default,https://www.example.com/culprit/path,successful JS title,12,10,,https://sentry.io/error/error_details\r",
         "",
     ]
 
@@ -196,6 +227,7 @@ def test_write_csv_with_enrichments(mocker):
         [
             {
                 "metadata": {"type": "warning", "value": "explanation of warning"},
+                "type": "error",
                 "culprit": "culprit body",
                 "count": 123,
                 "userCount": 3,
@@ -204,6 +236,7 @@ def test_write_csv_with_enrichments(mocker):
             },
             {
                 "metadata": {"type": "error", "value": "explanation of error"},
+                "type": "error",
                 "culprit": "culprit body",
                 "count": 12,
                 "userCount": 10,
@@ -268,7 +301,7 @@ async def test_export(mocker):
 async def test_export_with_enrichments(mocker):
     """Test the export function."""
 
-    async def enrich_issue_fn(ses, issue_to_enrich, enrs):
+    async def enrich_issue_fn(ses, issue_to_enrich, enrs):  # pylint: disable=unused-argument
         """Enrich the issue."""
         issue_to_enrich["_enriched"] = True
 


### PR DESCRIPTION
Sentry does not provide a schema for issue metatadata, so we were
previously unable to determine the appropriate shape for handling issue
metadata. After trawling their UI source code, I found the following:

```typescript
export function getMessage(event: Event): string | undefined {
  const {metadata, type, culprit} = event;

  switch (type) {
    case 'error':
      return metadata.value;
    case 'csp':
      return metadata.message;
    case 'expectct':
    case 'expectstaple':
    case 'hpkp':
      return '';
    default:
      return culprit || '';
  }
}
```

Based on that, we can determine that:

* The top-level issue `type` field should be the key upon which this all
  depends
* Errors and CSPs have a "details" value (via metadata). We already use
  the "culprit" field elsewhere in the row, so mapping this isn't
  necessary.  The `default` type has a `title` metadata value, so this pulls that in.

Fixes #13 