### PR TITLE
Handle cases where errors may not have subtypes in their metadata.

### DIFF
--- a/sentry2csv/sentry2csv.py
+++ b/sentry2csv/sentry2csv.py
@@ -98,7 +98,7 @@ def write_csv(filename: str, issues: List[Dict[str, Any]]):
                 #  https://github.com/getsentry/sentry/blob/9910cc917d2def63b110e75d4d17dedf7f415f58/src/sentry/static/sentry/app/utils/events.tsx#L7  # pylint: disable=line-too-long
                 issue_type = issue["type"]
                 if issue_type == "error":
-                    error = issue["metadata"]["type"]
+                    error = issue["metadata"].get("type", issue_type)  # get more specific if we can
                     details = issue["metadata"]["value"]
                 elif issue_type == "csp":
                     error = "csp"

--- a/tests/test_sentry2csv.py
+++ b/tests/test_sentry2csv.py
@@ -179,6 +179,14 @@ def test_write_csv(mocker):
                 "type": "error",
             },
             {
+                "metadata": {"value": "explanation of error"},
+                "culprit": "culprit body",
+                "count": 12,
+                "userCount": 10,
+                "permalink": "https://sentry.io/error/error_details",
+                "type": "error",
+            },
+            {
                 "metadata": {"message": "a CSP error"},
                 "culprit": "culprit body",
                 "count": 12,
@@ -209,6 +217,7 @@ def test_write_csv(mocker):
     assert output_buffer.getvalue().split("\n") == [
         "Error,Location,Details,Events,Users,Notes,Link\r",
         "warning,culprit body,explanation of warning,123,3,,https://sentry.io/warning/warning_details\r",
+        "error,culprit body,explanation of error,12,10,,https://sentry.io/error/error_details\r",
         "error,culprit body,explanation of error,12,10,,https://sentry.io/error/error_details\r",
         "csp,culprit body,a CSP error,12,10,,https://sentry.io/error/error_details\r",
         "hpkp,culprit body,,12,10,,https://sentry.io/error/error_details\r",


### PR DESCRIPTION
Sometimes `error` type issues don't have `metadata.type` fields.  When is encountered, fall back to `error`.

Fixes #13