### PR TITLE
Support self-hosted Sentry via --host argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Alternatively, you can install sentry2csv using standard pip.
     * For example, `sentry2csv --token f9u3fdu821ed9j10sj19kjd991010 sparkmeter TopSecretProject13`
 
 This also accepts an optional `--enrich` flag. Enrichments augment issues with data from the latest event.
-An enrichment is in the form of `CSV Field Name=dotted.sentry.path`, and multiple enrichments are comma-separated.
+An enrichment is in the form of `dotted.sentry.path=CSV_Field_Name`, and multiple enrichments are comma-separated.
 
 ## Development
 1. Clone this repository

--- a/sentry2csv/constant.py
+++ b/sentry2csv/constant.py
@@ -1,0 +1,3 @@
+"""Constants for use by sentry2csv"""
+
+SENTRY_HOST: str = "sentry.io"

--- a/sentry2csv/constant.py
+++ b/sentry2csv/constant.py
@@ -1,3 +1,0 @@
-"""Constants for use by sentry2csv"""
-
-SENTRY_HOST: str = "sentry.io"

--- a/sentry2csv/sentry2csv.py
+++ b/sentry2csv/sentry2csv.py
@@ -173,7 +173,7 @@ def main():
         metavar="HOST",
         nargs=1,
         required=False,
-        default=SENTRY_HOST,
+        default=[SENTRY_HOST],
         help=f"The Sentry host [default: {SENTRY_HOST}]",
     )
     parser.add_argument("organization", metavar="ORGANIZATION", nargs=1, help="The Sentry organization")

--- a/sentry2csv/sentry2csv.py
+++ b/sentry2csv/sentry2csv.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import aiohttp
 import pkg_resources  # part of setuptools
 
-from .constant import SENTRY_HOST
+SENTRY_HOST = "sentry.io"
 
 logging.basicConfig()
 logger = logging.getLogger(__name__)
@@ -52,10 +52,7 @@ async def fetch(
 
 
 async def enrich_issue(
-    session: aiohttp.ClientSession,
-    issue: Dict[str, Any],
-    enrichments: List[Enrichment],
-    host: Optional[str] = SENTRY_HOST,
+    session: aiohttp.ClientSession, issue: Dict[str, Any], enrichments: List[Enrichment], host: str = SENTRY_HOST
 ) -> None:
     """Enrich an issue with data from the latest event."""
     event, _ = await fetch(session, f'https://{host}/api/0/issues/{issue["id"]}/events/latest/')
@@ -132,11 +129,7 @@ def write_csv(filename: str, issues: List[Dict[str, Any]]):
 
 
 async def export(
-    token: str,
-    organization: str,
-    project: str,
-    enrich: Optional[List[Enrichment]] = None,
-    host: Optional[str] = SENTRY_HOST,
+    token: str, organization: str, project: str, enrich: Optional[List[Enrichment]] = None, host: str = SENTRY_HOST
 ):
     """Export data from Sentry to CSV."""
     enrichments: List[Enrichment] = enrich or []
@@ -176,7 +169,12 @@ def main():
     parser.add_argument("--enrich", help="Optional mappings of event metadata")
     parser.add_argument("--token", metavar="API_TOKEN", nargs=1, required=True, help="The Sentry API token")
     parser.add_argument(
-        "--host", metavar="HOST", nargs=1, required=False, help=f"The Sentry host [default: {SENTRY_HOST}]"
+        "--host",
+        metavar="HOST",
+        nargs=1,
+        required=False,
+        default=SENTRY_HOST,
+        help=f"The Sentry host [default: {SENTRY_HOST}]",
     )
     parser.add_argument("organization", metavar="ORGANIZATION", nargs=1, help="The Sentry organization")
     parser.add_argument("project", metavar="PROJECT", nargs=1, help="The Sentry project")

--- a/tests/test_sentry2csv.py
+++ b/tests/test_sentry2csv.py
@@ -310,7 +310,7 @@ async def test_export(mocker):
 async def test_export_with_enrichments(mocker):
     """Test the export function."""
 
-    async def enrich_issue_fn(ses, issue_to_enrich, enrs):  # pylint: disable=unused-argument
+    async def enrich_issue_fn(ses, issue_to_enrich, enrs, host):  # pylint: disable=unused-argument
         """Enrich the issue."""
         issue_to_enrich["_enriched"] = True
 


### PR DESCRIPTION
This adds support for running the script against a self-hosted Sentry cluster by passing the hostname via an optional `--host` command-line argument. By default, the script will still target `sentry.io`.

```sh
$ python3 ./sentry2csv.py --host sentry.example.com --token 2f53ea409f3a4b44895849e3fd448f exampleOrg MyProject
```

Further, this makes the main module executable directly, for ease of testing.