### PR TITLE
Python 3.10 compat

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,12 +10,15 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python_version: ["3.7", "3.10"]
     steps:
       - uses: actions/checkout@v1
-      - name: Set up Python 3.7
+      - name: Set up Python ${{ matrix.python_version }}
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: ${{ matrix.python_version }}
       - name: Setup project with pip
         run: "pip install -e .[dev]"
       - name: Check formatting

--- a/sentry2csv/sentry2csv.py
+++ b/sentry2csv/sentry2csv.py
@@ -93,7 +93,7 @@ def write_csv(filename: str, issues: List[Dict[str, Any]]):
     fieldnames = ["Error", "Location", "Details", "Events", "Users", "Notes", "Link"]
     if issues and "_enrichments" in issues[0]:
         fieldnames.extend(issues[0]["_enrichments"].keys())
-    with open(filename, "w") as outfile:
+    with open(filename, "w", encoding="utf-8") as outfile:
         writer = csv.DictWriter(outfile, fieldnames=fieldnames)
         writer.writeheader()
         for issue in issues:

--- a/setup.py
+++ b/setup.py
@@ -64,8 +64,8 @@ setup(
             "mypy-extensions==0.4.3",
             "types-setuptools==57.4.9",
             "pylint==2.4.2",
-            "pytest==5.2.2",
-            "pytest-asyncio==0.10.0",
+            "pytest==7.0.1",
+            "pytest-asyncio==0.18.1",
             "pytest-cov==2.8.1",
             "pytest-mock==1.11.2",
         ]

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
             "mypy==0.931",
             "mypy-extensions==0.4.3",
             "types-setuptools==57.4.9",
-            "pylint==2.4.2",
+            "pylint==2.12.2",
             "pytest==7.0.1",
             "pytest-asyncio==0.18.1",
             "pytest-cov==2.8.1",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r") as README:
     LONG_DESCRIPTION = README.read()
 
 REQUIREMENTS = [
-    "aiohttp==3.6.1",
+    "aiohttp==3.8.1",
 ]
 
 HERE = os.path.abspath(os.path.dirname(__file__))
@@ -57,11 +57,12 @@ setup(
     },
     extras_require={
         "dev": [
-            "aioresponses==0.6.1",
+            "aioresponses==0.7.3",
             "asynctest==0.13.0",
             "black==19.3b0",
-            "mypy==0.730",
-            "mypy-extensions==0.4.2",
+            "mypy==0.931",
+            "mypy-extensions==0.4.3",
+            "types-setuptools==57.4.9",
             "pylint==2.4.2",
             "pytest==5.2.2",
             "pytest-asyncio==0.10.0",


### PR DESCRIPTION
Bump the aiohttp version to a Python 3.10 compatible version.

Fixes #18 